### PR TITLE
Use stadium-specific images on event detail page

### DIFF
--- a/react-app/src/pages/userHomePage/EventDetailPage.tsx
+++ b/react-app/src/pages/userHomePage/EventDetailPage.tsx
@@ -29,6 +29,12 @@ interface EventSummary {
 
 const BASE_URL = import.meta.env.VITE_API_BASE || 'http://localhost:3000';
 
+// Mapeo entre nombres de estadios y la ruta de la imagen de su plano
+const STADIUM_IMAGE_MAP: Record<string, string> = {
+  'Estadio Monumental': '/stadiums/monumental.png',
+  'La Bombonera': '/stadiums/bombonera.png'
+};
+
 const EventDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -94,6 +100,9 @@ const EventDetailPage: React.FC = () => {
 
   if (loading) return <p>Cargando evento...</p>;
   if (!summary) return <p>Evento no encontrado</p>;
+
+  const stadiumImage =
+    STADIUM_IMAGE_MAP[summary.placeName] || summary.imageUrl;
 
   const handleAddToCart = () => {
     const token = localStorage.getItem('token');
@@ -218,7 +227,7 @@ const EventDetailPage: React.FC = () => {
       <div className={styles.eventDetailCard}>
         <div className={styles.eventImageContainer}>
           <img
-            src={summary.imageUrl}
+            src={stadiumImage}
             alt={summary.eventName}
             className={styles.eventImage}
             onError={(e) => {

--- a/react-app/src/pages/userHomePage/styles/EventDetailPage.module.css
+++ b/react-app/src/pages/userHomePage/styles/EventDetailPage.module.css
@@ -31,15 +31,18 @@
 
 .eventImageContainer {
   width: 100%;
-  height: 300px;
+  max-height: 400px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   overflow: hidden;
+  background: #e5e7eb;
 }
 
 .eventImage {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
-  background: #e5e7eb;
+  height: auto;
+  object-fit: contain;
 }
 
 .eventInfo {
@@ -142,7 +145,7 @@
   }
 
   .eventImageContainer {
-    height: 200px;
+    max-height: 200px;
   }
 
   .eventTitle {


### PR DESCRIPTION
## Summary
- map stadium names to their seating plan image paths
- show mapped stadium plan image on event detail page
- style event image container for proper plan layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f3a0c9f8832e967858cb972693ba